### PR TITLE
jdbc.db: activate clickhouse and derby dialect modules

### DIFF
--- a/dialect/db/pom.xml
+++ b/dialect/db/pom.xml
@@ -27,6 +27,8 @@
   <modules>
     <module>common</module>
     <module>test-support</module>
+    <module>clickhouse</module>
+    <module>derby</module>
     <module>duckdb</module>
     <module>h2</module>
     <module>mariadb</module>
@@ -40,9 +42,7 @@
 
 
     <module>access</module>
-    <module>clickhouse</module>
     <module>db2</module>
-    <module>derby</module>
     <module>firebird</module>
     <module>googlebigquery</module>
     <module>greenplum</module>


### PR DESCRIPTION
Move the ClickHouse and Derby dialects from the commented-out block into the active module list so they are built and released alongside the other dialects. Both compile and pass their tests against the current API; no source changes were needed.
