### PR TITLE
fix(duckdb): cast source to VARCHAR in regexp_matches

### DIFF
--- a/dialect/db/duckdb/src/main/java/org/eclipse/daanse/jdbc/db/dialect/db/duckdb/DuckDbDialect.java
+++ b/dialect/db/duckdb/src/main/java/org/eclipse/daanse/jdbc/db/dialect/db/duckdb/DuckDbDialect.java
@@ -141,9 +141,11 @@ public class DuckDbDialect extends AbstractJdbcDialect {
         }
         final StringBuilder sb = new StringBuilder();
         sb.append(source);
-        sb.append(" IS NOT NULL AND regexp_matches(");
+        // regexp_matches needs VARCHAR; DuckDB won't coerce numeric columns (e.g. store_sqft),
+        // so cast like PostgreSqlDialect does.
+        sb.append(" IS NOT NULL AND regexp_matches(CAST(");
         sb.append(source);
-        sb.append(", ");
+        sb.append(" AS VARCHAR), ");
         quoteStringLiteral(sb, javaRegex);
         if (mappedFlags.length() > 0) {
             sb.append(", ");


### PR DESCRIPTION
DuckDB's regexp_matches takes VARCHAR only and does not coerce implicitly, so applying MATCHES to a numeric column (e.g. store_sqft) failed with "No function matches ... 'regexp_matches(INTEGER, ...)'". Cast the source to VARCHAR, as PostgreSqlDialect already does.
